### PR TITLE
blinker 1.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4" %}
+{% set version = "1.5" %}
 
 package:
   name: blinker
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/b/blinker/blinker-{{ version }}.tar.gz
-  sha256: 471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6
+  sha256: 923e5e2f69c155f2cc42dafbbd70e16e3fde24d2d4aa2ab72fbe386238892462
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index ccbc0a6..2b127d4 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4" %}
+{% set version = "1.5" %}
 
 package:
   name: blinker
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/b/blinker/blinker-{{ version }}.tar.gz
-  sha256: 471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6
+  sha256: 923e5e2f69c155f2cc42dafbbd70e16e3fde24d2d4aa2ab72fbe386238892462
 
 build:
   number: 0

```

**Jira ticket:** []() (-)

**The upstream data:**

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority D | effort: easy | Category: other_key_deps | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 1.5
 * Release on PyPi:
    * version: 1.5
    * date: 2022-07-17T17:40:05
* [PyPi history](https://pypi.org/project/blinker/#history)
 * Popularity: 
    * 3 months downloads: 621675.0
    * All time:  7733636 downloads -  blinker  1.5  Fast, simple object-to-object and broadcast signaling  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
3. - [x] has `setuptools`
6. - [ ] Verify if the package needs `wheel`
    
8. - [ ] NO `pip` in test
    
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE is present

15. - [ ] License family is NOT present
    
16. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |
</details>

**Check dependency issues:**

<details>
../aggregate/blinker-feedstock/recipe/meta.yaml
Dependencies: ['setuptools', 'python']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 18**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/blinker-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/blinker-feedstock/tree/1.5)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/blinker)
* [Diff between upstream and feature branch](https://github.com/conda-forge/blinker-feedstock/compare/main...AnacondaRecipes:1.5)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/blinker-feedstock/compare/master...AnacondaRecipes:1.5)
* [The last merged PRs](https://github.com/AnacondaRecipes/blinker-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 1.5 git@github.com:AnacondaRecipes/blinker-feedstock.git
```
