### PR TITLE
blinker 1.9.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+pbp_autopublish: false
+
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "blinker" %}
-{% set version = "1.6.2" %}
+{% set version = "1.9.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/blinker-{{ version }}.tar.gz
-  sha256: 4afd3de66ef3a9f8067559fb7a1cbe555c17dcbe15971b05d1b625c3e7abe213
+  sha256: b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf
 
 build:
   number: 0
@@ -16,9 +16,8 @@ build:
 requirements:
   host:
     - python
-    - setuptools
     - pip
-    - wheel
+    - flit-core <4
   run:
     - python
 
@@ -27,22 +26,22 @@ test:
     - tests
   imports:
     - blinker
-  commands:
-    - pip check
-    - pytest --pyargs tests -vv
   requires:
     - pip
     - pytest
     - pytest-asyncio
+  commands:
+    - pip check
+    - pytest --pyargs tests -vv
 
 about:
   home: https://blinker.readthedocs.io/
   license: MIT
-  license_file: LICENSE.rst
+  license_file: LICENSE.txt
   license_family: MIT
   summary: Fast, simple object-to-object and broadcast signaling
   description: |
-    Blinker provides fast & simple object-to-object and broadcast 
+    Blinker provides fast & simple object-to-object and broadcast
     signaling for Python objects.
   dev_url: https://github.com/pallets-eco/blinker
   doc_url: https://blinker.readthedocs.io/


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6798](https://anaconda.atlassian.net/browse/PKG-6798)
- [Upstream repo](https://github.com/pallets-eco/blinker/tree/1.9.0)
- release-diff: https://github.com/pallets-eco/blinker/compare/1.6.2...1.9.0
- changelog: https://github.com/pallets-eco/blinker/blob/main/CHANGES.rst
- requirements-tagged:
  - https://github.com/pallets-eco/blinker/blob/1.9.0/pyproject.toml
  - https://github.com/pallets-eco/blinker/tree/1.9.0/requirements


### Explanation of changes:

- Replace setuptools and wheel by flit-core
- Fix license name

### Notes:

- flask 3.1.0 require it



[PKG-6798]: https://anaconda.atlassian.net/browse/PKG-6798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ