### PR TITLE
blinker 1.9.0: rebuild for py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
 pbp_autopublish: false
 
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313: yes
+  ANACONDA_ROCKET_ENABLE_PY314: yes

--- a/recipe/187.patch
+++ b/recipe/187.patch
@@ -1,0 +1,25 @@
+From cb2b55c211bcd3d622d525dd2cc1c7276d3d5b5c Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 18 Nov 2025 13:06:49 -0800
+Subject: [PATCH] Add asyncio fixture to test_async_receiver
+
+This ensures that this test executes and passes
+with pytest-8.4+
+
+pytest now throws errors for such functions [1]
+which were skipped in older versions
+---
+ tests/test_signals.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tests/test_signals.py b/tests/test_signals.py
+index 93a9c48..959209c 100644
+--- a/tests/test_signals.py
++++ b/tests/test_signals.py
+@@ -257,6 +257,7 @@ def received(sender: t.Any) -> None:
+     assert [id(fn) for fn in sig.receivers.values()] == [fn_id]
+ 
+ 
++@pytest.mark.asyncio
+ async def test_async_receiver() -> None:
+     sentinel = []

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ test:
     - pip
     - pytest
     - pytest-asyncio
+    - anyio
   commands:
     - pip check
     - pytest --pyargs tests -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,9 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/blinker-{{ version }}.tar.gz
   sha256: b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf
+  patches:
+    # Add asyncio fixture to test_async_receiver
+    - 187.patch
 
 build:
   number: 1
@@ -29,8 +32,9 @@ test:
   requires:
     - pip
     - pytest
+    # pytest-asyncio 1.0.0 is not compatible with blinker 1.9.0.
+    # Replace it with pytest-tornasync for now.
     #- pytest-asyncio
-    #- anyio
     - pytest-tornasync
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/blinker-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/blinker-{{ version }}.tar.gz
   sha256: b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf
 
 build:
-  number: 0
+  number: 1
   script: pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,8 +29,9 @@ test:
   requires:
     - pip
     - pytest
-    - pytest-asyncio
-    - anyio
+    #- pytest-asyncio
+    #- anyio
+    - pytest-tornasync
   commands:
     - pip check
     - pytest --pyargs tests -vv


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-11035) 
- [Upstream repository](https://github.com/pallets-eco/blinker/tree/1.9.0)

### Explanation of changes:

- Add a patch with asyncio fixture to `test_async_receiver`, see https://github.com/pallets-eco/blinker/pull/187
- Replace pytest-asyncio 1.0.0 (incompatible with blinker 1.9.0) with pytest-tornasync.

### Notes:

- flask-jwt-extended 4.7.1 requires blinker for py314 https://github.com/AnacondaRecipes/flask-jwt-extended-feedstock/pull/7/